### PR TITLE
feat: Event 기능 추가

### DIFF
--- a/src/main/java/com/shareday/calendar/enums/ParticipantType.java
+++ b/src/main/java/com/shareday/calendar/enums/ParticipantType.java
@@ -1,0 +1,7 @@
+package com.shareday.calendar.enums;
+
+public enum ParticipantType {
+    PERSONAL,   // 개인
+    SHARED,     // 공유
+    PARTNER     // 파트너
+}

--- a/src/main/java/com/shareday/event/controller/EventController.java
+++ b/src/main/java/com/shareday/event/controller/EventController.java
@@ -1,0 +1,66 @@
+package com.shareday.event.controller;
+
+
+import com.shareday.common.api.ApiResponse;
+import com.shareday.event.dto.EventRequest;
+import com.shareday.event.dto.EventResponse;
+import com.shareday.event.dto.EventUpdateRequest;
+import com.shareday.event.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@Tag(name = "이벤트 컨트롤러", description = "일정 이벤트 관리 API")
+@RequestMapping("/api/calendars/{calendarId}/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    public EventController(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    @GetMapping
+    @Operation(summary = "이벤트 목록 조회", description = "캘린더 ID와 기간으로 일정을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<EventResponse>>> getEvents(
+            @PathVariable Long calendarId,
+            @RequestParam LocalDate start,
+            @RequestParam LocalDate end
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(eventService.getEvents(calendarId, start, end)));
+    }
+
+    @PostMapping
+    @Operation(summary = "이벤트 생성", description = "새로운 일정을 등록합니다.")
+    public ResponseEntity<ApiResponse<EventResponse>> createEvent(
+            @PathVariable Long calendarId,
+            @RequestBody EventRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(eventService.createEvent(calendarId, request)));
+    }
+
+    @PatchMapping("/{eventId}")
+    @Operation(summary = "이벤트 수정", description = "이벤트 ID로 일정을 수정합니다.")
+    public ResponseEntity<ApiResponse<EventResponse>> updateEvent(
+            @PathVariable Long calendarId,
+            @PathVariable Long eventId,
+            @RequestBody EventUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(eventService.updateEvent(calendarId, eventId, request)));
+    }
+
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "이벤트 삭제", description = "이벤트 ID로 일정을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteEvent(
+            @PathVariable Long calendarId,
+            @PathVariable Long eventId
+    ) {
+        eventService.deleteEvent(eventId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/shareday/event/dto/EventRequest.java
+++ b/src/main/java/com/shareday/event/dto/EventRequest.java
@@ -1,0 +1,46 @@
+package com.shareday.event.dto;
+
+import com.shareday.common.annotaion.ValidEnum;
+import com.shareday.event.enums.ParticipantType;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record EventRequest(
+
+        Long coupleId,
+
+        Long userId,
+
+        @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+        @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 1000, message = "설명은 최대 1000자까지 입력 가능합니다.")
+        String description,
+
+        @NotNull(message = "이벤트 날짜는 필수입니다.")
+        @FutureOrPresent(message = "이벤트 날짜는 오늘 또는 미래여야 합니다.")
+        LocalDate eventDate,
+
+        @NotNull(message = "시작 시간은 필수입니다.")
+        LocalDateTime startTime,
+
+        @NotNull(message = "종료 시간은 필수입니다.")
+        LocalDateTime endTime,
+
+        @NotBlank(message = "생성자 정보는 필수입니다.")
+        @Size(max = 100, message = "생성자 정보는 최대 100자까지 입력 가능합니다.")
+        String createdBy,
+
+        @Size(max = 255, message = "참여자 목록은 255자를 넘을 수 없습니다.")
+        String participants,
+
+        @NotNull(message = "참여자 유형은 필수입니다.")
+        @ValidEnum(enumClass = ParticipantType.class, message = "참여자 값이 올바르지 않습니다.")
+        ParticipantType participantType,
+
+        @NotNull(message = "D-Day 여부는 필수입니다.")
+        Boolean isDday
+) {}

--- a/src/main/java/com/shareday/event/dto/EventResponse.java
+++ b/src/main/java/com/shareday/event/dto/EventResponse.java
@@ -1,0 +1,23 @@
+package com.shareday.event.dto;
+
+import com.shareday.event.enums.ParticipantType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record EventResponse(
+        Long eventId,
+        Long coupleId,
+        Long userId,
+        String title,
+        String description,
+        LocalDate eventDate,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        String createdBy,
+        String participants,
+        ParticipantType type,
+        Boolean isDday,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/shareday/event/dto/EventUpdateRequest.java
+++ b/src/main/java/com/shareday/event/dto/EventUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.shareday.event.dto;
+
+import com.shareday.event.enums.ParticipantType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record EventUpdateRequest(
+        String title,
+        String description,
+        LocalDate eventDate,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        String participants,
+        ParticipantType type,
+        Boolean isDday
+) {}

--- a/src/main/java/com/shareday/event/entity/Event.java
+++ b/src/main/java/com/shareday/event/entity/Event.java
@@ -1,0 +1,69 @@
+package com.shareday.event.entity;
+
+import com.shareday.event.enums.ParticipantType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long eventId;
+
+    private Long coupleId;
+    private Long userId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDate eventDate;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false, length = 100)
+    private String createdBy;
+
+    private String participants;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipantType type;
+
+    @Column(nullable = false)
+    private Boolean isDday = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/shareday/event/enums/ParticipantType.java
+++ b/src/main/java/com/shareday/event/enums/ParticipantType.java
@@ -1,0 +1,7 @@
+package com.shareday.event.enums;
+
+public enum ParticipantType {
+    PERSONAL,   // 개인
+    SHARED,     // 공유
+    PARTNER     // 파트너
+}

--- a/src/main/java/com/shareday/event/repository/EventRepository.java
+++ b/src/main/java/com/shareday/event/repository/EventRepository.java
@@ -1,0 +1,11 @@
+package com.shareday.event.repository;
+
+import com.shareday.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findByEventDateBetweenAndCoupleId(LocalDate start, LocalDate end, Long coupleId);
+}

--- a/src/main/java/com/shareday/event/service/EventService.java
+++ b/src/main/java/com/shareday/event/service/EventService.java
@@ -1,0 +1,80 @@
+package com.shareday.event.service;
+
+
+import com.shareday.event.dto.*;
+import com.shareday.event.entity.Event;
+import com.shareday.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public List<EventResponse> getEvents(Long calendarId, LocalDate start, LocalDate end) {
+        return eventRepository.findByEventDateBetweenAndCoupleId(start, end, calendarId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public EventResponse createEvent(Long calendarId, EventRequest request) {
+        Event event = Event.builder()
+                .coupleId(calendarId)
+                .userId(request.userId())
+                .title(request.title())
+                .description(request.description())
+                .eventDate(request.eventDate())
+                .startTime(request.startTime())
+                .endTime(request.endTime())
+                .createdBy(request.createdBy())
+                .participants(request.participants())
+                .type(request.participantType())
+                .isDday(request.isDday())
+                .build();
+        return toResponse(eventRepository.save(event));
+    }
+
+    public EventResponse updateEvent(Long calendarId, Long eventId, EventUpdateRequest request) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found"));
+
+        event.setTitle(request.title());
+        event.setDescription(request.description());
+        event.setEventDate(request.eventDate());
+        event.setStartTime(request.startTime());
+        event.setEndTime(request.endTime());
+        event.setParticipants(request.participants());
+        event.setType(request.type());
+        event.setIsDday(request.isDday());
+
+        return toResponse(eventRepository.save(event));
+    }
+
+    public void deleteEvent(Long eventId) {
+        eventRepository.deleteById(eventId);
+    }
+
+    private EventResponse toResponse(Event e) {
+        return new EventResponse(
+                e.getEventId(),
+                e.getCoupleId(),
+                e.getUserId(),
+                e.getTitle(),
+                e.getDescription(),
+                e.getEventDate(),
+                e.getStartTime(),
+                e.getEndTime(),
+                e.getCreatedBy(),
+                e.getParticipants(),
+                e.getType(),
+                e.getIsDday(),
+                e.getCreatedAt(),
+                e.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 📌 feat: Event 기능 추가 및 ParticipantType enum 분리

<!-- 여기에 간단히 어떤 변경인지 적어주세요 -->

## ✅ 변경 내용
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 문서 업데이트

## 📝 설명
- Calendar 엔티티에 Event 생성/조회/수정/삭제 기능 추가
- 기존 엔티티 내부에 정의된 EventType enum을 제거하고, 별도 파일 ParticipantType으로 분리
- 의미를 명확히 하기 위해 EventType → ParticipantType으로 이름 변경

## 🧪 테스트 방법
- Event 생성 API 호출 시 participantType 값(PERSONAL/SHARED/PARTNER) 전달
- Event 조회/수정/삭제 기능 동작 확인
- DB calendar_event 테이블에 participant_type 값 정상 저장 여부 확인

## 🔗 관련 이슈
Closes #이슈번호
