### PR TITLE
feat: Calendar 엔티티 EventType enum 분리 및 ParticipantType 적용

### DIFF
--- a/src/main/java/com/shareday/calendar/dto/CalendarCreateRequest.java
+++ b/src/main/java/com/shareday/calendar/dto/CalendarCreateRequest.java
@@ -1,6 +1,8 @@
 package com.shareday.calendar.dto;
 
 import com.shareday.calendar.entity.Calendar;
+import com.shareday.calendar.enums.ParticipantType;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -12,6 +14,6 @@ public record CalendarCreateRequest(
         String createdBy,
         String participants,
         String description,
-        Calendar.EventType type,
+        ParticipantType participantType,
         boolean isDDay
 ) {}

--- a/src/main/java/com/shareday/calendar/dto/CalendarResponse.java
+++ b/src/main/java/com/shareday/calendar/dto/CalendarResponse.java
@@ -1,6 +1,8 @@
 package com.shareday.calendar.dto;
 
 import com.shareday.calendar.entity.Calendar;
+import com.shareday.calendar.enums.ParticipantType;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -13,7 +15,7 @@ public record CalendarResponse(
         String createdBy,
         String participants,
         String description,
-        Calendar.EventType type,
+        ParticipantType participantType,
         boolean isDDay,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/com/shareday/calendar/dto/CalendarUpdateRequest.java
+++ b/src/main/java/com/shareday/calendar/dto/CalendarUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.shareday.calendar.dto;
 
 import com.shareday.calendar.entity.Calendar;
+import com.shareday.calendar.enums.ParticipantType;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -11,6 +13,6 @@ public record CalendarUpdateRequest(
         LocalDateTime endTime,
         String participants,
         String description,
-        Calendar.EventType type,
+        ParticipantType participantType,
         boolean isDDay
 ) {}

--- a/src/main/java/com/shareday/calendar/entity/Calendar.java
+++ b/src/main/java/com/shareday/calendar/entity/Calendar.java
@@ -1,6 +1,7 @@
 package com.shareday.calendar.entity;
 
 //import com.shareday.user.entity.User;
+import com.shareday.calendar.enums.ParticipantType;
 import com.shareday.couple.entity.Couple;
 import jakarta.persistence.*;
 
@@ -10,10 +11,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "calendar_event")
 public class Calendar {
-
-    public enum EventType {
-        PERSONAL, SHARED, PARTNER
-    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // BIGINT AUTO_INCREMENT
@@ -56,7 +53,7 @@ public class Calendar {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    private EventType type;
+    private ParticipantType type;
 
     @Column(name = "is_dday", nullable = false)
     private boolean isDDay = false;
@@ -71,7 +68,7 @@ public class Calendar {
 
     public Calendar(String title, LocalDate eventDate, LocalDateTime startTime, LocalDateTime endTime,
                     String createdBy, String participants, String description,
-                    EventType type, boolean isDDay) {
+                    ParticipantType type, boolean isDDay) {
         this.title = title;
         this.eventDate = eventDate;
         this.startTime = startTime;
@@ -105,7 +102,7 @@ public class Calendar {
     public LocalDateTime getEndTime() { return endTime; }
     public String getCreatedBy() { return createdBy; }
     public String getParticipants() { return participants; }
-    public EventType getType() { return type; }
+    public ParticipantType getType() { return type; }
     public boolean isDDay() { return isDDay; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
@@ -113,7 +110,7 @@ public class Calendar {
     // Update
     public void update(String title, LocalDate eventDate, LocalDateTime startTime,
                        LocalDateTime endTime, String participants,
-                       String description, EventType type, boolean isDDay) {
+                       String description, ParticipantType type, boolean isDDay) {
         this.title = title;
         this.eventDate = eventDate;
         this.startTime = startTime;

--- a/src/main/java/com/shareday/calendar/service/CalendarService.java
+++ b/src/main/java/com/shareday/calendar/service/CalendarService.java
@@ -27,7 +27,7 @@ public class CalendarService {
                 request.createdBy(),
                 request.participants(),
                 request.description(),
-                request.type(),
+                request.participantType(),
                 request.isDDay()
         );
         return CalendarResponse.from(calendarRepository.save(event));
@@ -58,7 +58,7 @@ public class CalendarService {
                 request.endTime(),
                 request.participants(),
                 request.description(),
-                request.type(),
+                request.participantType(),
                 request.isDDay()
         );
         return CalendarResponse.from(event);

--- a/src/main/java/com/shareday/couple/controller/CoupleController.java
+++ b/src/main/java/com/shareday/couple/controller/CoupleController.java
@@ -22,6 +22,7 @@ public class CoupleController {
         this.coupleService = coupleService;
     }
 
+    //TODO:: 각 API가 무슨기능을 하는지 깃 이슈에 정리하기
     @PostMapping
     @Operation(summary = "커플 생성", description = "새로운 커플을 등록합니다.")
     public ResponseEntity<ApiResponse<CoupleResponse>> create(@RequestBody CoupleRequest request) {

--- a/src/main/java/com/shareday/couple/dto/CoupleRequest.java
+++ b/src/main/java/com/shareday/couple/dto/CoupleRequest.java
@@ -1,5 +1,7 @@
 package com.shareday.couple.dto;
 
+import com.shareday.auth.entity.User;
+
 import java.time.LocalDate;
 
 public record CoupleRequest(


### PR DESCRIPTION
## 📌 PR 제목

<!-- 여기에 간단히 어떤 변경인지 적어주세요 -->

## ✅ 변경 내용
- [ ] 버그 수정
- [ ] 기능 추가
- [x] 문서 업데이트

## 📝 설명
- Calendar 엔티티에 Event 생성/조회/수정/삭제 기능 추가
- 엔티티 내부에 있던 EventType enum 제거 후 ParticipantType enum으로 분리
- 코드 가독성 및 유지보수성을 위해 이름을 EventType → ParticipantType으로 변경

## 🧪 테스트 방법

## 🔗 관련 이슈
Closes #이슈번호
