### PR TITLE
feat : couple 초대 코드 생성 및 수락 API 추가

### DIFF
--- a/src/main/java/com/shareday/couple/controller/CoupleController.java
+++ b/src/main/java/com/shareday/couple/controller/CoupleController.java
@@ -2,14 +2,14 @@ package com.shareday.couple.controller;
 
 import com.shareday.couple.dto.CoupleRequest;
 import com.shareday.couple.dto.CoupleResponse;
+import com.shareday.couple.dto.InviteAcceptRequest;
+import com.shareday.couple.dto.InviteResponse;
 import com.shareday.couple.service.CoupleService;
 import com.shareday.common.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @Tag(name = "커플 컨트롤러", description = "커플 관리 API")
@@ -29,18 +29,6 @@ public class CoupleController {
         return ResponseEntity.ok(ApiResponse.ok(coupleService.create(request)));
     }
 
-    @GetMapping
-    @Operation(summary = "커플 목록 조회", description = "등록된 모든 커플을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<CoupleResponse>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.ok(coupleService.findAll()));
-    }
-
-    @GetMapping("/{coupleId}")
-    @Operation(summary = "커플 단건 조회", description = "커플 ID로 특정 커플을 조회합니다.")
-    public ResponseEntity<ApiResponse<CoupleResponse>> getOne(@PathVariable Long coupleId) {
-        return ResponseEntity.ok(ApiResponse.ok(coupleService.findById(coupleId)));
-    }
-
     @PatchMapping("/{coupleId}")
     @Operation(summary = "커플 수정", description = "커플 ID에 해당하는 커플 정보를 수정합니다. (교제 시작일)")
     public ResponseEntity<ApiResponse<CoupleResponse>> update(
@@ -50,9 +38,21 @@ public class CoupleController {
     }
 
     @DeleteMapping("/{coupleId}")
-    @Operation(summary = "커플 삭제", description = "커플 ID에 해당하는 커플을 삭제합니다.")
+    @Operation(summary = "커플 해제", description = "커플 ID에 해당하는 커플을 해제합니다.")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long coupleId) {
         coupleService.delete(coupleId);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @PostMapping("/invite")
+    @Operation(summary = "초대 코드 생성", description = "커플 초대 코드를 생성합니다.")
+    public ResponseEntity<ApiResponse<InviteResponse>> invite() {
+        return ResponseEntity.ok(ApiResponse.ok(coupleService.generateInviteCode()));
+    }
+
+    @PostMapping("/accept")
+    @Operation(summary = "초대 코드 수락", description = "초대 코드를 이용해 커플을 수락합니다.")
+    public ResponseEntity<ApiResponse<CoupleResponse>> accept(@RequestBody InviteAcceptRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(coupleService.acceptInvite(request)));
     }
 }

--- a/src/main/java/com/shareday/couple/dto/InviteAcceptRequest.java
+++ b/src/main/java/com/shareday/couple/dto/InviteAcceptRequest.java
@@ -1,0 +1,5 @@
+package com.shareday.couple.dto;
+
+public record InviteAcceptRequest(
+        String inviteCode
+) {}

--- a/src/main/java/com/shareday/couple/dto/InviteResponse.java
+++ b/src/main/java/com/shareday/couple/dto/InviteResponse.java
@@ -1,0 +1,5 @@
+package com.shareday.couple.dto;
+
+public record InviteResponse(
+        String inviteCode
+) {}

--- a/src/main/java/com/shareday/couple/service/CoupleService.java
+++ b/src/main/java/com/shareday/couple/service/CoupleService.java
@@ -2,12 +2,14 @@ package com.shareday.couple.service;
 
 import com.shareday.couple.dto.CoupleRequest;
 import com.shareday.couple.dto.CoupleResponse;
+import com.shareday.couple.dto.InviteAcceptRequest;
+import com.shareday.couple.dto.InviteResponse;
 import com.shareday.couple.entity.Couple;
 import com.shareday.couple.repository.CoupleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -15,17 +17,8 @@ public class CoupleService {
 
     private final CoupleRepository coupleRepository;
 
-    public List<CoupleResponse> findAll() {
-        return coupleRepository.findAll().stream()
-                .map(c -> new CoupleResponse(c.getCoupleId(), c.getStartDate(), c.getCreatedAt(), c.getUpdatedAt()))
-                .toList();
-    }
-
-    public CoupleResponse findById(Long id) {
-        Couple couple = coupleRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Couple not found"));
-        return new CoupleResponse(couple.getCoupleId(), couple.getStartDate(), couple.getCreatedAt(), couple.getUpdatedAt());
-    }
+    // 간단히 메모리 맵으로 초대 코드 저장 (실제 운영에서는 Redis, DB 사용 권장)
+    private final Map<String, Long> inviteCodeStore = new HashMap<>();
 
     public CoupleResponse create(CoupleRequest request) {
         Couple couple = Couple.builder()
@@ -45,5 +38,29 @@ public class CoupleService {
 
     public void delete(Long id) {
         coupleRepository.deleteById(id);
+    }
+
+    public InviteResponse generateInviteCode() {
+        String code = UUID.randomUUID().toString().substring(0, 8);
+        // 여기서는 단순히 ID 0과 매핑 (실제 구현은 로그인 사용자 ID와 매핑 필요)
+        inviteCodeStore.put(code, 0L);
+        return new InviteResponse(code);
+    }
+
+    public CoupleResponse acceptInvite(InviteAcceptRequest request) {
+        Long inviterId = inviteCodeStore.get(request.inviteCode());
+        if (inviterId == null) {
+            throw new IllegalArgumentException("Invalid invite code");
+        }
+
+        Couple couple = Couple.builder()
+                .startDate(null) // 교제 시작일은 이후 수정 가능
+                .build();
+        Couple saved = coupleRepository.save(couple);
+
+        // 사용된 코드 삭제
+        inviteCodeStore.remove(request.inviteCode());
+
+        return new CoupleResponse(saved.getCoupleId(), saved.getStartDate(), saved.getCreatedAt(), saved.getUpdatedAt());
     }
 }


### PR DESCRIPTION
## 📌 PR 제목

커플 초대 코드 생성 및 수락 API 추가

## ✅ 변경 내용
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 문서 업데이트

## 📝 설명
- 기존 GET /couples/{id}, GET /couples 조회 API 대신 초대 코드 기반 커플 연결 기능을 추가
- POST /couples/invite: 초대 코드 발급 (UUID 기반, 현재는 메모리 맵으로 관리)
- POST /couples/accept: 초대 코드 수락 후 커플 생성
- 초대 코드 관리용 DTO(InviteResponse, InviteAcceptRequest) 추가
- CoupleService에 초대 코드 발급 및 수락 로직 구현

## 🧪 테스트 방법


## 🔗 관련 이슈
Closes #이슈번호
