### PR TITLE
refactor: 초대코드 Redis 대신 DB에 저장하도록 수정

### DIFF
--- a/src/main/java/com/shareday/couple/controller/CoupleController.java
+++ b/src/main/java/com/shareday/couple/controller/CoupleController.java
@@ -44,11 +44,12 @@ public class CoupleController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @PostMapping("/invite")
+    @PostMapping("/{coupleId}/invite")
     @Operation(summary = "초대 코드 생성", description = "커플 초대 코드를 생성합니다.")
-    public ResponseEntity<ApiResponse<InviteResponse>> invite() {
-        return ResponseEntity.ok(ApiResponse.ok(coupleService.generateInviteCode()));
+    public ResponseEntity<ApiResponse<InviteResponse>> invite(@PathVariable Long coupleId) {
+        return ResponseEntity.ok(ApiResponse.ok(coupleService.generateInviteCode(coupleId)));
     }
+
 
     @PostMapping("/accept")
     @Operation(summary = "초대 코드 수락", description = "초대 코드를 이용해 커플을 수락합니다.")

--- a/src/main/java/com/shareday/couple/dto/CoupleResponse.java
+++ b/src/main/java/com/shareday/couple/dto/CoupleResponse.java
@@ -7,5 +7,5 @@ public record CoupleResponse(
         Long coupleId,
         LocalDate startDate,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt //교제 시작일을 변경했을 때 기록
 ) {}

--- a/src/main/java/com/shareday/couple/entity/Couple.java
+++ b/src/main/java/com/shareday/couple/entity/Couple.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.time.LocalDate;
 import lombok.*;
-
 @Entity
 @Table(name = "couple")
 @Getter
@@ -19,6 +18,10 @@ public class Couple {
     private Long coupleId;
 
     private LocalDate startDate;
+
+    // 초대 코드 (삭제되지 않고 계속 유지)
+    @Column(unique = true, length = 20)
+    private String inviteCode;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/shareday/couple/repository/CoupleRepository.java
+++ b/src/main/java/com/shareday/couple/repository/CoupleRepository.java
@@ -3,5 +3,8 @@ package com.shareday.couple.repository;
 import com.shareday.couple.entity.Couple;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
+    Optional<Couple> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/shareday/couple/service/CoupleService.java
+++ b/src/main/java/com/shareday/couple/service/CoupleService.java
@@ -9,7 +9,7 @@ import com.shareday.couple.repository.CoupleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -17,15 +17,17 @@ public class CoupleService {
 
     private final CoupleRepository coupleRepository;
 
-    // 간단히 메모리 맵으로 초대 코드 저장 (실제 운영에서는 Redis, DB 사용 권장)
-    private final Map<String, Long> inviteCodeStore = new HashMap<>();
-
     public CoupleResponse create(CoupleRequest request) {
         Couple couple = Couple.builder()
                 .startDate(request.startDate())
                 .build();
         Couple saved = coupleRepository.save(couple);
-        return new CoupleResponse(saved.getCoupleId(), saved.getStartDate(), saved.getCreatedAt(), saved.getUpdatedAt());
+        return new CoupleResponse(
+                saved.getCoupleId(),
+                saved.getStartDate(),
+                saved.getCreatedAt(),
+                saved.getUpdatedAt()
+        );
     }
 
     public CoupleResponse update(Long id, CoupleRequest request) {
@@ -33,34 +35,47 @@ public class CoupleService {
                 .orElseThrow(() -> new IllegalArgumentException("Couple not found"));
         couple.setStartDate(request.startDate());
         Couple updated = coupleRepository.save(couple);
-        return new CoupleResponse(updated.getCoupleId(), updated.getStartDate(), updated.getCreatedAt(), updated.getUpdatedAt());
+        return new CoupleResponse(
+                updated.getCoupleId(),
+                updated.getStartDate(),
+                updated.getCreatedAt(),
+                updated.getUpdatedAt()
+        );
     }
 
     public void delete(Long id) {
         coupleRepository.deleteById(id);
     }
 
-    public InviteResponse generateInviteCode() {
+    // 초대 코드 생성 (DB에 영구 저장)
+    public InviteResponse generateInviteCode(Long coupleId) {
+        Couple couple = coupleRepository.findById(coupleId)
+                .orElseThrow(() -> new IllegalArgumentException("Couple not found"));
+
+        if (couple.getInviteCode() != null) {
+            // 이미 코드 있으면 그대로 반환
+            return new InviteResponse(couple.getInviteCode());
+        }
+
         String code = UUID.randomUUID().toString().substring(0, 8);
-        // 여기서는 단순히 ID 0과 매핑 (실제 구현은 로그인 사용자 ID와 매핑 필요)
-        inviteCodeStore.put(code, 0L);
+        couple.setInviteCode(code);
+        coupleRepository.save(couple);
+
         return new InviteResponse(code);
     }
 
+    // 초대 코드 수락
     public CoupleResponse acceptInvite(InviteAcceptRequest request) {
-        Long inviterId = inviteCodeStore.get(request.inviteCode());
-        if (inviterId == null) {
-            throw new IllegalArgumentException("Invalid invite code");
-        }
+        Couple couple = coupleRepository.findByInviteCode(request.inviteCode())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid invite code"));
 
-        Couple couple = Couple.builder()
-                .startDate(null) // 교제 시작일은 이후 수정 가능
-                .build();
-        Couple saved = coupleRepository.save(couple);
-
-        // 사용된 코드 삭제
-        inviteCodeStore.remove(request.inviteCode());
-
-        return new CoupleResponse(saved.getCoupleId(), saved.getStartDate(), saved.getCreatedAt(), saved.getUpdatedAt());
+        // 필요하다면 수락 로직 추가 (예: 상대방 유저 등록)
+        // 여기서는 단순히 커플 정보 반환
+        return new CoupleResponse(
+                couple.getCoupleId(),
+                couple.getStartDate(),
+                couple.getCreatedAt(),
+                couple.getUpdatedAt()
+        );
     }
 }


### PR DESCRIPTION
## 📌 PR 제목

<!-- 여기에 간단히 어떤 변경인지 적어주세요 -->

## ✅ 변경 내용
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 문서 업데이트

## 📝 설명
- 기존에는 HashMap(인메모리 저장)을 사용하여 초대코드 관리
- 서버 재시작 시 데이터가 사라지는 문제 존재
- 초대코드는 한 사람당 기한 없이 유지되어야 하므로 DB 저장 방식으로 변경
- Couple 엔티티에 inviteCode 필드 추가
- CoupleRepository에 findByInviteCode 메서드 추가
- CoupleService에서 초대코드 생성/조회 로직을 DB 기반으로 리팩토링

## 🧪 테스트 방법
테스트 케이스나 재현 방법을 적어주세요.

## 🔗 관련 이슈
Closes #이슈번호
