### PR TITLE
Feature/event

### DIFF
--- a/src/main/java/com/shareday/event/controller/EventController.java
+++ b/src/main/java/com/shareday/event/controller/EventController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @Tag(name = "이벤트 컨트롤러", description = "일정 이벤트 관리 API")
-@RequestMapping("/api/events")
+@RequestMapping("/api/calendars/{calendarId}/events")
 public class EventController {
 
     private final EventService eventService;
@@ -26,18 +26,19 @@ public class EventController {
     }
 
     @GetMapping
-    @Operation(summary = "이벤트 목록 조회", description = "커플 ID와 기간으로 일정을 조회합니다.")
+    @Operation(summary = "이벤트 목록 조회", description = "캘린더 ID와 기간으로 일정을 조회합니다.")
     public ResponseEntity<ApiResponse<List<EventResponse>>> getEvents(
-            @RequestParam Long coupleId,
+            @PathVariable Long calendarId,
             @RequestParam LocalDate start,
             @RequestParam LocalDate end
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(eventService.getEvents(coupleId, start, end)));
+        return ResponseEntity.ok(ApiResponse.ok(eventService.getEvents(calendarId, start, end)));
     }
 
     @PostMapping
     @Operation(summary = "이벤트 생성", description = "새로운 일정을 등록합니다.")
     public ResponseEntity<ApiResponse<EventResponse>> createEvent(
+            @PathVariable Long calendarId,
             @Valid @RequestBody EventRequest request
     ) {
         return ResponseEntity.ok(ApiResponse.ok(eventService.createEvent(request)));
@@ -46,6 +47,7 @@ public class EventController {
     @PatchMapping("/{eventId}")
     @Operation(summary = "이벤트 수정", description = "이벤트 ID로 일정을 수정합니다.")
     public ResponseEntity<ApiResponse<EventResponse>> updateEvent(
+            @PathVariable Long calendarId,
             @PathVariable Long eventId,
             @Valid @RequestBody EventUpdateRequest request
     ) {
@@ -55,6 +57,7 @@ public class EventController {
     @DeleteMapping("/{eventId}")
     @Operation(summary = "이벤트 삭제", description = "이벤트 ID로 일정을 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deleteEvent(
+            @PathVariable Long calendarId,
             @PathVariable Long eventId
     ) {
         eventService.deleteEvent(eventId);

--- a/src/main/java/com/shareday/event/controller/EventController.java
+++ b/src/main/java/com/shareday/event/controller/EventController.java
@@ -26,13 +26,12 @@ public class EventController {
     }
 
     @GetMapping
-    @Operation(summary = "이벤트 목록 조회", description = "커플 ID와 기간으로 일정을 조회합니다.")
+    @Operation(summary = "이벤트 목록 조회", description = "기간으로 일정을 조회합니다.")
     public ResponseEntity<ApiResponse<List<EventResponse>>> getEvents(
-            @RequestParam Long coupleId,
             @RequestParam LocalDate start,
             @RequestParam LocalDate end
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(eventService.getEvents(coupleId, start, end)));
+        return ResponseEntity.ok(ApiResponse.ok(eventService.getEvents(start, end)));
     }
 
     @PostMapping

--- a/src/main/java/com/shareday/event/dto/EventRequest.java
+++ b/src/main/java/com/shareday/event/dto/EventRequest.java
@@ -1,6 +1,5 @@
 package com.shareday.event.dto;
 
-import com.shareday.common.annotaion.ValidEnum;
 import com.shareday.event.enums.ParticipantType;
 import jakarta.validation.constraints.*;
 
@@ -8,9 +7,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record EventRequest(
-
-        @NotNull(message = "커플 ID는 필수입니다.")
-        Long coupleId,
 
         @NotNull(message = "사용자 ID는 필수입니다.")
         Long userId,
@@ -32,6 +28,5 @@ public record EventRequest(
         LocalDateTime endTime,
 
         @NotNull(message = "참여자 유형은 필수입니다.")
-        @ValidEnum(enumClass = ParticipantType.class, message = "참여자 값이 올바르지 않습니다.")
         ParticipantType participantType
 ) {}

--- a/src/main/java/com/shareday/event/entity/Event.java
+++ b/src/main/java/com/shareday/event/entity/Event.java
@@ -20,8 +20,8 @@ public class Event {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long eventId;
 
-    @Column(nullable = false)
-    private Long coupleId;
+//    @Column(nullable = false)
+//    private Long coupleId;
 
     @Column(nullable = false)
     private Long userId;

--- a/src/main/java/com/shareday/event/repository/EventRepository.java
+++ b/src/main/java/com/shareday/event/repository/EventRepository.java
@@ -7,5 +7,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    List<Event> findByEventDateBetweenAndCoupleId(LocalDate start, LocalDate end, Long coupleId);
+    List<Event> findByEventDateBetween(LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/shareday/event/service/EventService.java
+++ b/src/main/java/com/shareday/event/service/EventService.java
@@ -15,15 +15,16 @@ public class EventService {
 
     private final EventRepository eventRepository;
 
-    public List<EventResponse> getEvents(Long coupleId, LocalDate start, LocalDate end) {
-        return eventRepository.findByEventDateBetweenAndCoupleId(start, end, coupleId).stream()
+    // ✅ 이벤트 목록 조회
+    public List<EventResponse> getEvents(LocalDate start, LocalDate end) {
+        return eventRepository.findByEventDateBetween(start, end).stream()
                 .map(this::toResponse)
                 .toList();
     }
 
+    // ✅ 이벤트 생성
     public EventResponse createEvent(EventRequest request) {
         Event event = Event.builder()
-                .coupleId(request.coupleId())
                 .userId(request.userId())
                 .title(request.title())
                 .description(request.description())
@@ -36,6 +37,7 @@ public class EventService {
         return toResponse(eventRepository.save(event));
     }
 
+    // ✅ 이벤트 수정
     public EventResponse updateEvent(Long eventId, EventUpdateRequest request) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
@@ -50,10 +52,12 @@ public class EventService {
         return toResponse(eventRepository.save(event));
     }
 
+    // ✅ 이벤트 삭제
     public void deleteEvent(Long eventId) {
         eventRepository.deleteById(eventId);
     }
 
+    // ✅ 엔티티 → DTO 변환
     private EventResponse toResponse(Event e) {
         return new EventResponse(
                 e.getEventId(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/shareday?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: #비밀번호
+    password: gPdnjs75312@
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
## 📌 PR 제목
EventRequest DTO에서 coupleId 제거 및 이벤트 생성 로직 수정  

## ✅ 변경 내용
- [x] 버그 수정  
- [ ] 기능 추가  
- [ ] 문서 업데이트  

## 📝 설명
- 기존 `EventRequest` DTO에 포함되어 있던 `coupleId` 필드가 이벤트 생성 시 누락되어 
   DB `NOT NULL` 제약 조건으로 인해 저장이 실패하던 문제가 있었습니다.  
- API 요청 시 더 이상 `coupleId`를 받지 않도록 DTO를 수정하고, 서비스 로직을 이에 맞춰 정리했습니다.  

## 🧪 테스트 방법
1. 서버 실행 후  
2. `POST /api/events` 요청 시 아래와 같은 JSON Body 전달  
   ```json
   {
     "userId": 1,
     "title": "테스트 이벤트",
     "description": "테스트 설명",
     "eventDate": "2025-09-30",
     "startTime": "2025-09-30T10:00:00",
     "endTime": "2025-09-30T11:00:00",
     "participantType": "PERSONAL"
   }

