### PR TITLE
update : 카카오 로그인 DB 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,15 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 환경 변수 파일
+.env
+
+# IDE 설정 파일
+.idea/
+*.iml
+
+# 빌드 산출물
+/build/
+/out/
+/target/

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,13 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'mysql:mysql-connector-java:8.0.33'
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/src/main/java/com/shareday/SharedayBeApplication.java
+++ b/src/main/java/com/shareday/SharedayBeApplication.java
@@ -2,12 +2,23 @@ package com.shareday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.core.env.Environment;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @SpringBootApplication
 public class SharedayBeApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SharedayBeApplication.class, args);
-	}
+    @Autowired
+    private Environment env;   // ✅ Environment 주입
 
+    public static void main(String[] args) {
+        SpringApplication.run(SharedayBeApplication.class, args);
+    }
+
+    @PostConstruct
+    public void checkEnv() {
+        System.out.println("👉 KAKAO_CLIENT_ID = " + env.getProperty("KAKAO_CLIENT_ID"));
+        System.out.println("👉 KAKAO_CLIENT_SECRET = " + env.getProperty("KAKAO_CLIENT_SECRET"));
+    }
 }

--- a/src/main/java/com/shareday/auth/controller/AuthController.java
+++ b/src/main/java/com/shareday/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.shareday.auth.controller;
 
+import com.shareday.auth.dto.SocialLoginRequest;
+import com.shareday.auth.dto.SocialLoginResponse;
 import com.shareday.auth.service.AuthService;
 import com.shareday.auth.dto.SocialSignUpRequest;
 import com.shareday.auth.dto.SocialSignUpResponse;
@@ -7,24 +9,31 @@ import com.shareday.common.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
 @Tag(name = "인증 컨트롤러", description = "인증")
+@RequiredArgsConstructor
 public class AuthController {
 
-    private AuthService authService;
+    private final AuthService authService;
 
     @PostMapping("/social-signUp")
     @Operation(summary = "회원가입", description = "회원가입")
-    public ResponseEntity<ApiResponse<SocialSignUpResponse>> socialSignUp (
+    public ResponseEntity<ApiResponse<SocialSignUpResponse>> socialSignUp(
             @Valid @RequestBody SocialSignUpRequest request
     ) {
         return ResponseEntity.ok(ApiResponse.ok(authService.socialSignUp(request)));
+    }
+
+    @PostMapping("/social-login/kakao")
+    @Operation(summary = "카카오 로그인", description = "카카오 AccessToken으로 로그인 (회원가입 겸용)")
+    public ResponseEntity<ApiResponse<SocialLoginResponse>> kakaoLogin(
+            @Valid @RequestBody SocialLoginRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.kakaoLogin(request)));
     }
 }

--- a/src/main/java/com/shareday/auth/dto/SocialLoginRequest.java
+++ b/src/main/java/com/shareday/auth/dto/SocialLoginRequest.java
@@ -1,0 +1,8 @@
+package com.shareday.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialLoginRequest(
+        @NotBlank(message = "AccessToken은 필수입니다.")
+        String accessToken
+) { }

--- a/src/main/java/com/shareday/auth/dto/SocialLoginResponse.java
+++ b/src/main/java/com/shareday/auth/dto/SocialLoginResponse.java
@@ -1,0 +1,23 @@
+package com.shareday.auth.dto;
+
+import com.shareday.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record SocialLoginResponse(
+        Long userId,
+        String email,
+        String nickname,
+        String jwtToken,
+        boolean isNewUser
+) {
+    public static SocialLoginResponse from(User user, String token, boolean isNewUser) {
+        return SocialLoginResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .jwtToken(token)
+                .isNewUser(isNewUser)
+                .build();
+    }
+}

--- a/src/main/java/com/shareday/auth/dto/SocialSignUpRequest.java
+++ b/src/main/java/com/shareday/auth/dto/SocialSignUpRequest.java
@@ -8,5 +8,5 @@ public record SocialSignUpRequest(
         ProviderType provider,
 
         @NotBlank(message = "accessToken은 필수입니다.")
-        String accessToken // 또는 authorizationCode
+        String accessToken
 ) { }

--- a/src/main/java/com/shareday/auth/enums/ProviderType.java
+++ b/src/main/java/com/shareday/auth/enums/ProviderType.java
@@ -1,7 +1,7 @@
 package com.shareday.auth.enums;
 
 public enum ProviderType {
-    google,
-    naver,
-    kakao
+    GOOGLE,
+    NAVER,
+    KAKAO
 }

--- a/src/main/java/com/shareday/auth/oauth/DefaultOAuthUserInfoProvider.java
+++ b/src/main/java/com/shareday/auth/oauth/DefaultOAuthUserInfoProvider.java
@@ -23,9 +23,9 @@ public class DefaultOAuthUserInfoProvider implements OAuthUserInfoProvider {
     @Override
     public OAuthUserInfo getUserInfo(ProviderType provider, String accessToken) {
         return switch (provider) {
-            case google -> fetchGoogleUser(accessToken);
-            case naver -> fetchNaverUser(accessToken);
-            case kakao -> fetchKakaoUser(accessToken);
+            case GOOGLE -> fetchGoogleUser(accessToken);
+            case NAVER -> fetchNaverUser(accessToken);
+            case KAKAO -> fetchKakaoUser(accessToken);
         };
     }
 
@@ -36,7 +36,7 @@ public class DefaultOAuthUserInfoProvider implements OAuthUserInfoProvider {
 
         Map<String, Object> body = response.getBody();
         return new OAuthUserInfo(
-                ProviderType.google,
+                ProviderType.GOOGLE,
                 (String) body.get("id"),
                 (String) body.get("email"),
                 (String) body.get("name")
@@ -50,7 +50,7 @@ public class DefaultOAuthUserInfoProvider implements OAuthUserInfoProvider {
 
         Map<String, Object> resp = (Map<String, Object>) response.getBody().get("response");
         return new OAuthUserInfo(
-                ProviderType.naver,
+                ProviderType.NAVER,
                 (String) resp.get("id"),
                 (String) resp.get("email"),
                 (String) resp.get("name")
@@ -67,7 +67,7 @@ public class DefaultOAuthUserInfoProvider implements OAuthUserInfoProvider {
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
         return new OAuthUserInfo(
-                ProviderType.kakao,
+                ProviderType.KAKAO,
                 String.valueOf(body.get("id")),
                 (String) kakaoAccount.get("email"),
                 (String) profile.get("nickname")

--- a/src/main/java/com/shareday/auth/service/AuthService.java
+++ b/src/main/java/com/shareday/auth/service/AuthService.java
@@ -3,28 +3,29 @@ package com.shareday.auth.service;
 import com.shareday.auth.dto.OAuthUserInfo;
 import com.shareday.auth.dto.SocialSignUpRequest;
 import com.shareday.auth.dto.SocialSignUpResponse;
+import com.shareday.auth.dto.SocialLoginRequest;
+import com.shareday.auth.dto.SocialLoginResponse;
 import com.shareday.auth.entity.Auth;
 import com.shareday.auth.enums.ProviderType;
 import com.shareday.auth.oauth.JwtProvider;
 import com.shareday.auth.oauth.OAuthUserInfoProvider;
 import com.shareday.auth.repository.AuthRepository;
+import com.shareday.user.entity.User;
+import com.shareday.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
     private final OAuthUserInfoProvider oAuthUserInfoProvider;
     private final AuthRepository authRepository;
     private final JwtProvider jwtProvider;
-
-    public AuthService(OAuthUserInfoProvider oAuthUserInfoProvider,
-                       AuthRepository authRepository,
-                       JwtProvider jwtProvider) {
-        this.oAuthUserInfoProvider = oAuthUserInfoProvider;
-        this.authRepository = authRepository;
-        this.jwtProvider = jwtProvider;
-    }
+    private final UserRepository userRepository;
 
     @Transactional
     public SocialSignUpResponse socialSignUp(SocialSignUpRequest request) {
@@ -38,7 +39,6 @@ public class AuthService {
         var existing = authRepository.findByEmail(userInfo.email());
 
         Auth auth = existing.orElseGet(() -> {
-            // userInfo.provider()가 이미 ProviderType이면 그대로 사용
             ProviderType provider = (userInfo.provider() instanceof ProviderType p)
                     ? p
                     : ProviderType.valueOf(userInfo.provider().toString().toUpperCase());
@@ -46,6 +46,16 @@ public class AuthService {
         });
 
         boolean isNewUser = existing.isEmpty();
+
+        if (isNewUser) {
+            User user = User.builder()
+                    .auth(auth)
+                    .email(auth.getEmail())
+                    .nickname(auth.getNickname())
+                    .provider(auth.getProvider())
+                    .build();
+            userRepository.save(user);
+        }
 
         String token = jwtProvider.generateToken(auth.getId(), auth.getEmail());
 
@@ -57,5 +67,80 @@ public class AuthService {
                 token,
                 isNewUser
         );
+    }
+
+    @Transactional
+    public SocialLoginResponse kakaoLogin(SocialLoginRequest request) {
+        OAuthUserInfo userInfo =
+                oAuthUserInfoProvider.getUserInfo(ProviderType.KAKAO, request.accessToken());
+
+        if (userInfo == null || userInfo.email() == null || userInfo.email().isBlank()) {
+            throw new IllegalArgumentException("유효한 이메일을 제공하지 않는 소셜 계정입니다.");
+        }
+
+        var existingAuth = authRepository.findByEmail(userInfo.email());
+
+        Auth auth = existingAuth.orElseGet(() ->
+                authRepository.save(new Auth(userInfo.email(), userInfo.nickname(), ProviderType.KAKAO))
+        );
+
+        boolean isNewUser = existingAuth.isEmpty();
+
+        User user = userRepository.findByKakaoId(userInfo.providerId()).orElseGet(() -> {
+            User newUser = User.builder()
+                    .kakaoId(userInfo.providerId())
+                    .email(userInfo.email())
+                    .nickname(userInfo.nickname())
+                    .provider(auth.getProvider())
+                    .auth(auth)
+                    .build();
+            return userRepository.save(newUser);
+        });
+
+        String token = jwtProvider.generateToken(auth.getId(), auth.getEmail());
+
+        return SocialLoginResponse.from(user, token, isNewUser);
+    }
+
+    /**
+     * ✅ OAuth2 로그인 시 (SecurityConfig successHandler에서 호출)
+     * 이메일 기반으로 Auth/User 저장 또는 조회 후 User 반환
+     */
+    @Transactional
+    public User saveOrUpdate(String email, String nickname, ProviderType provider, String providerId) {
+        log.info("🔎 saveOrUpdate called with email={}, nickname={}, provider={}, providerId={}",
+                email, nickname, provider, providerId);
+
+        Auth authEntity = authRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    log.info("✅ 신규 Auth 생성 -> email={}", email);
+                    Auth newAuth = Auth.builder()
+                            .email(email)
+                            .nickname(nickname)
+                            .provider(provider)
+                            .build();
+                    return authRepository.saveAndFlush(newAuth);
+                });
+
+        User userEntity = userRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    log.info("✅ 신규 User 생성 -> email={}", email);
+                    User newUser = User.builder()
+                            .email(email)
+                            .nickname(nickname)
+                            .auth(authEntity)
+                            .provider(provider)
+                            .kakaoId(provider == ProviderType.KAKAO ? providerId : null)
+                            .build();
+                    User saved = userRepository.saveAndFlush(newUser); // flush 강제 실행
+                    log.info("✅ User 저장 완료 -> id={}, email={}", saved.getId(), saved.getEmail());
+                    return saved;
+                });
+
+        // ✅ JWT 발급 (여기서는 단순 로그만, SecurityConfig에서 최종 발급)
+        String jwtToken = jwtProvider.generateToken(userEntity.getId(), userEntity.getEmail());
+        log.info("✅ JWT 발급 완료 -> token={}", jwtToken);
+
+        return userEntity;
     }
 }

--- a/src/main/java/com/shareday/common/config/SecurityConfig.java
+++ b/src/main/java/com/shareday/common/config/SecurityConfig.java
@@ -1,7 +1,12 @@
 package com.shareday.common.config;
 
+import com.shareday.auth.enums.ProviderType;
+import com.shareday.auth.oauth.JwtProvider;
+import com.shareday.auth.service.AuthService;
 import com.shareday.auth.service.CustomOAuth2UserService;
+import com.shareday.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,12 +23,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final JwtProvider jwtProvider;
+    private final AuthService authService;
 
     @Value("${app.cors.allowed-origins}")
     private String allowedOrigins;
@@ -33,6 +41,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)   // ✅ 폼 로그인 비활성화
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/login/**").permitAll()
                         .requestMatchers(
@@ -40,49 +49,92 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/api/**"
+                                "/api/**",
+                                "/auth/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler((request, response, authentication) -> {
-                            var oauthUser = (org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal();
-                            var auth = (org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken) authentication;
-                            String registrationId = auth.getAuthorizedClientRegistrationId(); // google, naver, kakao
+                            log.info(">>> [OAuth2 SuccessHandler] authentication = {}", authentication);
 
-                            String name = null;
+                            if (authentication instanceof org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken authTokenDebug) {
+                                log.info(">>> [OAuth2 SuccessHandler] registrationId = {}", authTokenDebug.getAuthorizedClientRegistrationId());
+                            }
+
+                            var oauthUser = (org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal();
+                            var authToken = (org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken) authentication;
+                            String registrationId = authToken.getAuthorizedClientRegistrationId(); // google, naver, kakao
+
+                            log.info("✅ Provider(registrationId) = {}", registrationId);
+                            log.info("✅ OAuth2User Attributes = {}", oauthUser.getAttributes());
+
+                            String email = null;
+                            String nickname = null;
+                            String providerId = null;
+
+                            ProviderType providerType = ProviderType.valueOf(registrationId.toUpperCase());
+                            log.info("✅ ProviderType Enum = {}", providerType);
 
                             switch (registrationId) {
                                 case "google" -> {
-                                    name = oauthUser.getAttribute("name");
+                                    email = oauthUser.getAttribute("email");
+                                    nickname = oauthUser.getAttribute("name");
+                                    providerId = oauthUser.getName();
                                 }
                                 case "naver" -> {
                                     var responseMap = (Map<String, Object>) oauthUser.getAttribute("response");
                                     if (responseMap != null) {
-                                        name = (String) responseMap.get("name");
-                                        if (name == null) {
-                                            name = (String) responseMap.get("nickname");
+                                        email = (String) responseMap.get("email");
+                                        nickname = (String) responseMap.get("name");
+                                        if (nickname == null) {
+                                            nickname = (String) responseMap.get("nickname");
                                         }
+                                        providerId = (String) responseMap.get("id");
                                     }
                                 }
                                 case "kakao" -> {
+                                    providerId = oauthUser.getAttribute("id").toString();
                                     var accountMap = (Map<String, Object>) oauthUser.getAttribute("kakao_account");
                                     if (accountMap != null) {
+                                        email = (String) accountMap.get("email");
                                         var profileMap = (Map<String, Object>) accountMap.get("profile");
                                         if (profileMap != null) {
-                                            name = (String) profileMap.get("nickname");
+                                            nickname = (String) profileMap.get("nickname");
                                         }
                                     }
                                 }
                             }
 
-                            if (name == null) {
-                                name = "사용자"; // fallback 방어 코드
+                            if (nickname == null) nickname = "사용자";
+
+                            // ✅ 카카오 이메일 없으면 대체 이메일 생성
+                            if (providerType == ProviderType.KAKAO && (email == null || email.isBlank())) {
+                                email = "kakao_" + providerId + "@kakao.com";
+                                log.warn("⚠️ 카카오 이메일 없음 -> 대체 email 생성: {}", email);
                             }
 
-                            String redirectUrl = "http://localhost:5173/?userName=" +
-                                    URLEncoder.encode(name, StandardCharsets.UTF_8);
+                            // ✅ AuthService를 통해 Auth/User 저장 & 조회
+                            User userEntity = authService.saveOrUpdate(email, nickname, providerType, providerId);
 
+                            // ✅ JWT 발급
+                            String jwtToken = jwtProvider.generateToken(userEntity.getId(), userEntity.getEmail());
+                            log.info("✅ JWT 발급 완료 -> {}", jwtToken);
+
+                            // ✅ 프론트 리다이렉트 (token + userName 같이 전달)
+                            String redirectUrl = "http://localhost:5173/?token=" +
+                                    URLEncoder.encode(jwtToken, StandardCharsets.UTF_8) +
+                                    "&userName=" +
+                                    URLEncoder.encode(userEntity.getNickname(), StandardCharsets.UTF_8);
+
+                            log.info("✅ Redirect to frontend -> {}", redirectUrl);
+
+                            response.sendRedirect(redirectUrl);
+                        })
+                        .failureHandler((request, response, exception) -> {
+                            log.error("❌ [OAuth2 FailureHandler] 로그인 실패", exception);
+                            String redirectUrl = "http://localhost:5173/login?error=" +
+                                    URLEncoder.encode(exception.getMessage(), StandardCharsets.UTF_8);
                             response.sendRedirect(redirectUrl);
                         })
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))

--- a/src/main/java/com/shareday/user/entity/User.java
+++ b/src/main/java/com/shareday/user/entity/User.java
@@ -1,5 +1,6 @@
-package com.shareday.auth.entity;
+package com.shareday.user.entity;
 
+import com.shareday.auth.entity.Auth;
 import com.shareday.auth.enums.ProviderType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,35 +9,36 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
-@Getter @Setter
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity
 @Builder
-@Table(name = "auth") // 필요시 다른 테이블명으로 변경
-public class Auth {
+public class User {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
     private String email;
-
     private String nickname;
+    private String kakaoId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProviderType provider;
 
+    @OneToOne
+    @JoinColumn(name = "auth_id")
+    private Auth auth;
+
     @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-
-    public Auth(String email, String nickname, ProviderType provider) {
-        this.email = email;
-        this.nickname = nickname;
-        this.provider = provider;
-    }
 }

--- a/src/main/java/com/shareday/user/repository/UserRepository.java
+++ b/src/main/java/com/shareday/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.shareday.user.repository;
+
+import com.shareday.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(String kakaoId);
+
+    // ✅ 이메일로 User 찾기
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,13 +3,13 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://hskoo.xyz:3308/shareday?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: user
-    password: user1234!
+    url: jdbc:mysql://localhost:3306/shareday?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: gPdnjs75312@
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: none      # 개발 환경에서만 사용! (create, update, validate 등)
+      ddl-auto: update      # 개발 환경에서만 사용! (create, update, validate 등)
     show-sql: true          # 콘솔에 SQL 출력
     properties:
       hibernate:
@@ -26,6 +26,8 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile,email
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+            client-name: Google
+            provider: google
 
           naver:
             client-id: ${NAVER_CLIENT_ID}
@@ -43,7 +45,7 @@ spring:
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
-            scope: profile_nickname
+            scope: profile_nickname,account_email,profile_image
             client-name: Kakao
             provider: kakao
 


### PR DESCRIPTION
## 📌 PR 제목

update : 카카오 로그인 DB 연동

## ✅ 변경 내용
- [ ] 버그 수정
- [ ] 기능 추가
- [X] 문서 업데이트

## 📝 설명
- 카카오 로그인 성공 시 사용자 정보를 DB에 저장/갱신하도록 연동
- 최초 로그인 시 `users`, `auth` 테이블에 사용자 row 자동 추가
- 카카오 계정 이메일이 없는 경우 대체 이메일(`kakao_{id}@kakao.com`) 생성
- JWT 토큰 발급 후 프론트엔드로 전달되도록 SuccessHandler 로직 수정

## 🧪 테스트 방법
테스트 케이스나 재현 방법을 적어주세요.

## 🔗 관련 이슈
Closes #이슈번호
